### PR TITLE
Removed "ID" header from list of torrent IDs

### DIFF
--- a/insert-trackers-single
+++ b/insert-trackers-single
@@ -88,7 +88,7 @@ done
 
 # Get list of active torrents
 
-ids="$(transmission-remote "$host" --auth="$auth" --list | grep -vE 'Seeding|Stopped|Finished' | grep '^ ' | awk '{ print $1 }')"
+ids="$(transmission-remote "$host" --auth="$auth" --list | grep -vE 'Seeding|Stopped|Finished' | grep '^ ' | awk '{ print $1 }' | tail -n +2)"
 
 for id in $ids ; do
 torrent_name="$(transmission-remote "$host" --auth="$auth"  --torrent "$id" --info | grep '^  Name: ' |cut -c 9-)"


### PR DESCRIPTION
The inclusion of the transmission-remote header "ID" was causing this script to break.  This removes that header.